### PR TITLE
Add check to make sure there is actual heading text

### DIFF
--- a/creoleparser/elements.py
+++ b/creoleparser/elements.py
@@ -1261,7 +1261,10 @@ class Heading(BlockElement):
         else:
             heading_text = bldr.tag(heading_body).generate().render(method='text',encoding=None)
             used_ids = environ.setdefault('ids', [])
-            id_ = self.make_id(self.id_prefix,heading_text,used_ids)
+            if heading_text:
+                id_ = self.make_id(self.id_prefix,heading_text,used_ids)
+            else:
+                id_ = None
             used_ids.append(id_)
             #toc = environ.setdefault('toc', [])
             #toc.append((heading_tag, bldr.tag(heading_body), id_))            


### PR DESCRIPTION
If someone inputs an incorrect header (for example, by using something like "=====" as a separator), the parser will give a TypeError in make_id, as it tries to create an ID for non-existing text.

This check makes sure that we don't create incorrect heading IDs, as these strings are not indicating actual headings.